### PR TITLE
Fixes invalid handling of recaptcha hash update

### DIFF
--- a/docs/01_fetch_manager.md
+++ b/docs/01_fetch_manager.md
@@ -33,7 +33,7 @@ Depending on the form template, predefined Element Transformers are used automat
 
 ### Custom Element Transformers
 
-Use the elementTransformer option to customize the validations. Use this option when a custom form template is set.
+Use the sformer option to customize the validations. Use this option when a custom form template is set.
 
 ```js
 new FetchManager(form, {
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
             onSuccess: (messages, redirect) => {
                 console.log(messages, redirect);
             },
-            validationTransformer: {
+            elementTransformer: {
                 addValidationMessage: (field, messages) => {
                     console.log(field, messages);
                 },

--- a/docs/01_fetch_manager.md
+++ b/docs/01_fetch_manager.md
@@ -33,11 +33,11 @@ Depending on the form template, predefined Element Transformers are used automat
 
 ### Custom Element Transformers
 
-Use the validationTransformer option to customize the validations. Use this option when a custom form template is set.
+Use the elementTransformer option to customize the validations. Use this option when a custom form template is set.
 
 ```js
 new FetchManager(form, {
-    validationTransformer: {
+    elementTransformer: {
         addValidationMessage: (field, messages) => {
             form.classList.add('error-form');
             field.classList.add('error-field');

--- a/src/js/components/recaptchaV3.js
+++ b/src/js/components/recaptchaV3.js
@@ -1,4 +1,4 @@
-import {RECAPTCHA_V3_DEFAULTS} from '../constants/defaults';
+import {EVENTS, RECAPTCHA_V3_DEFAULTS} from '../constants/defaults';
 import {getScript, isNode} from '../utils/helpers';
 
 export default class RecaptchaV3 {
@@ -27,8 +27,8 @@ export default class RecaptchaV3 {
         this.siteKey = this.reCaptchaField.dataset.siteKey;
         this.action = this.reCaptchaField.dataset.actionName;
 
-        this.form.addEventListener('formbuilder.success', () => this.onReset());
-        this.form.addEventListener('formbuilder.fail', () => this.onReset());
+        this.form.addEventListener(EVENTS.success, () => this.onReset());
+        this.form.addEventListener(EVENTS.error, () => this.onReset());
 
         this.bindDependency();
     }
@@ -53,11 +53,11 @@ export default class RecaptchaV3 {
             return;
         }
 
-        if (typeof window.grecaptcha === 'undefined') {
+        if (!window.grecaptcha) {
             return;
         }
 
-        if (!this.reCaptchaField.length) {
+        if (!this.reCaptchaField) {
             return;
         }
 
@@ -70,7 +70,7 @@ export default class RecaptchaV3 {
             grecaptcha.execute(this.siteKey, {action: this.action})
                 .then((token) => this.onTokenGenerated(token));
         } catch (error) {
-            this.form.dispatchEvent(new CustomEvent('formbuilder.fatal-captcha'));
+            this.form.dispatchEvent(new CustomEvent(EVENTS.fatalCaptcha));
         }
     }
 

--- a/src/js/components/repeater.js
+++ b/src/js/components/repeater.js
@@ -1,4 +1,4 @@
-import {REPEATER_DEFAULTS} from '../constants/defaults';
+import { EVENTS, REPEATER_DEFAULTS } from '../constants/defaults';
 import {isFunction, isNode} from '../utils/helpers';
 
 export default class Repeater {
@@ -22,7 +22,7 @@ export default class Repeater {
 
         blocks.forEach((block) => this.addRemoveBlockButton(block, container));
 
-        container.addEventListener('formbuilder.repeater.container.update', (ev) => {
+        container.addEventListener(EVENTS.repeaterContainerUpdate, (ev) => {
             this.reRenderBlockLabels(ev.target);
         });
     }
@@ -112,10 +112,10 @@ export default class Repeater {
             this.reRenderBlockLabels(container);
             this.addRemoveBlockButton(newBlock, container);
             this.verifyButtonStates(container);
-            this.form.dispatchEvent(new CustomEvent('formbuilder.layout.post.add', {detail: {layout: newBlock}}));
+            this.form.dispatchEvent(new CustomEvent(EVENTS.layoutPostAdd, {detail: {layout: newBlock}}));
         };
 
-        this.form.dispatchEvent(new CustomEvent('formbuilder.layout.pre.add', {detail: {layout: newBlock}}));
+        this.form.dispatchEvent(new CustomEvent(EVENTS.layoutPreAdd, {detail: {layout: newBlock}}));
 
         if (isFunction(this.options.onAdd)) {
             this.options.onAdd(container, newForm, cb);
@@ -134,10 +134,10 @@ export default class Repeater {
         cb = () => {
             this.reRenderBlockLabels(container);
             this.verifyButtonStates(container);
-            this.form.dispatchEvent(new CustomEvent('formbuilder.layout.post.remove', {detail: {layout: containerBlock}}));
+            this.form.dispatchEvent(new CustomEvent(EVENTS.layoutPostRemove, {detail: {layout: containerBlock}}));
         };
 
-        this.form.dispatchEvent(new CustomEvent('formbuilder.layout.pre.remove', {detail: {layout: containerBlock}}));
+        this.form.dispatchEvent(new CustomEvent(EVENTS.layoutPreRemove, {detail: {layout: containerBlock}}));
 
         if (isFunction(this.options.onRemove)) {
             this.options.onRemove(container, cb);

--- a/src/js/components/tracker.js
+++ b/src/js/components/tracker.js
@@ -1,4 +1,4 @@
-import {TRACKER_DEFAULTS} from '../constants/defaults';
+import { EVENTS, TRACKER_DEFAULTS } from '../constants/defaults';
 import {isObject, isString, isFunction} from '../utils/helpers';
 
 export default class Tracker {
@@ -8,7 +8,7 @@ export default class Tracker {
         this.options = Object.assign(TRACKER_DEFAULTS, options);
         this.form = form;
 
-        this.form.addEventListener('formbuilder.success', (ev) => this.onSubmission(ev));
+        this.form.addEventListener(EVENTS.success, (ev) => this.onSubmission(ev));
     }
 
     onSubmission(ev) {

--- a/src/js/constants/defaults.js
+++ b/src/js/constants/defaults.js
@@ -56,3 +56,21 @@ export const CONDITIONAL_LOGIC_DEFAULTS = {
     elementTransformer: null,
     hideElementClass: 'fb-cl-hide-element',
 };
+
+export const EVENTS = {
+    success: 'formbuilder.success',
+    error: 'formbuilder.error',
+    errorForm: 'formbuilder.error-form',
+    errorField: 'formbuilder.error-field',
+    done: 'formbuilder.done',
+    fatal: 'formbuilder.fatal',
+    fatalCaptcha: 'formbuilder.fatal-captcha',
+    requestDone: 'formbuilder.request-done',
+    repeaterContainerUpdate: 'formbuilder.repeater.container.update',
+    layoutPostAdd: 'formbuilder.layout.post.add',
+    layoutPreAdd: 'formbuilder.layout.pre.add',
+    layoutPostRemove: 'formbuilder.layout.post.remove',
+    layoutPreRemove: 'formbuilder.layout.pre.remove',
+    dynamicMultiFileInit: 'formbuilder.dynamic_multi_file.init',
+    dynamicMultiFileDropzoneInit: 'formbuilder.dynamic_multi_file.dropzone.init'
+};

--- a/src/js/core/fetchManager.js
+++ b/src/js/core/fetchManager.js
@@ -1,4 +1,4 @@
-import {FETCH_MANAGER_DEFAULTS} from '../constants/defaults';
+import {EVENTS, FETCH_MANAGER_DEFAULTS} from '../constants/defaults';
 import Endpoints from './endpoints';
 import ElementTransformer from './elementTransformer';
 import {TYPE_VALIDATION} from '../constants/elementTransformer';
@@ -127,22 +127,22 @@ export default class FetchManager {
     onRequestDone(form, data) {
         this.options.onRequestDone(data);
         this.elementTransformer.transform('removeFormValidations', form);
-        form.dispatchEvent(new CustomEvent('formbuilder.done'));
+        form.dispatchEvent(new CustomEvent(EVENTS.done));
     }
 
     onFail(form, data) {
         this.options.onFail(data);
-        form.dispatchEvent(new CustomEvent('formbuilder.error'));
+        form.dispatchEvent(new CustomEvent(EVENTS.error));
     }
 
     onFatalError(form, data) {
         this.options.onFatalError(data);
-        form.dispatchEvent(new CustomEvent('formbuilder.fatal'));
+        form.dispatchEvent(new CustomEvent(EVENTS.fatal));
     }
 
     onGeneralError(form, generalErrorMessages) {
         this.options.onGeneralError(generalErrorMessages);
-        form.dispatchEvent(new CustomEvent('formbuilder.error-form'));
+        form.dispatchEvent(new CustomEvent(EVENTS.errorForm));
     }
 
     onErrorField(form, field, messages) {
@@ -151,12 +151,12 @@ export default class FetchManager {
             messages: messages,
         });
         this.elementTransformer.transform('addValidationMessage', form, field, messages);
-        form.dispatchEvent(new CustomEvent('formbuilder.error-field'));
+        form.dispatchEvent(new CustomEvent(EVENTS.errorField));
     }
 
     onSuccess(form, data) {
         this.options.onSuccess(data.messages, data.redirect);
-        form.dispatchEvent(new CustomEvent('formbuilder.success'));
+        form.dispatchEvent(new CustomEvent(EVENTS.success));
     }
 
 }

--- a/src/js/dynamicMultiFileHandlers/dropzoneHandler.js
+++ b/src/js/dynamicMultiFileHandlers/dropzoneHandler.js
@@ -1,4 +1,4 @@
-import {DYNAMIC_MULTI_FILE_DROPZONE_DEFAULTS} from '../constants/defaults';
+import {DYNAMIC_MULTI_FILE_DROPZONE_DEFAULTS, EVENTS} from '../constants/defaults';
 import Endpoints from '../core/endpoints';
 import Dropzone from 'dropzone';
 
@@ -44,7 +44,7 @@ export default class DropzoneHandler {
                 uploadMultiple: config.multiple,
                 init: () => {
                     template.remove();
-                    this.form.dispatchEvent(new CustomEvent('formbuilder.dynamic_multi_file.dropzone.init'));
+                    this.form.dispatchEvent(new CustomEvent(EVENTS.dynamicMultiFileDropzoneInit));
                 },
             };
 
@@ -58,7 +58,7 @@ export default class DropzoneHandler {
 
         dropzoneConfiguration = Object.assign(dropzoneConfiguration, this.options.dropzoneOptions);
 
-        this.form.dispatchEvent(new CustomEvent('formbuilder.dynamic_multi_file.init', {detail: [el, this.options, dropzoneConfiguration]}));
+        this.form.dispatchEvent(new CustomEvent(EVENTS.dynamicMultiFileInit, {detail: [el, this.options, dropzoneConfiguration]}));
         element.classList.add('dropzone');
 
         new Dropzone(element, dropzoneConfiguration)
@@ -119,14 +119,14 @@ export default class DropzoneHandler {
 
         });
 
-        this.form.addEventListener('formbuilder.request-done', (ev) => {
+        this.form.addEventListener(EVENTS.requestDone, (ev) => {
 
             let elements = ev.target.querySelectorAll('.dz-remove');
             elements.forEach((el) => el.style.display = 'block');
 
         });
 
-        this.form.addEventListener('formbuilder.success', (ev) => {
+        this.form.addEventListener(EVENTS.success, (ev) => {
 
             let elements = ev.target.querySelectorAll('[data-dynamic-multi-file-instance]');
             elements.forEach((el) => {
@@ -150,14 +150,14 @@ export default class DropzoneHandler {
 
         });
 
-        this.form.addEventListener('formbuilder.layout.post.add', (ev) => {
+        this.form.addEventListener(EVENTS.layoutPostAdd, (ev) => {
 
             let elements = ev.detail.layout.querySelectorAll('[data-dynamic-multi-file-instance]');
             elements.forEach((el) => this.setupDropZoneElement(el));
 
         });
 
-        this.form.addEventListener('formbuilder.layout.pre.remove', (ev) => {
+        this.form.addEventListener(EVENTS.layoutPreRemove, (ev) => {
 
             let elements = ev.detail.layout.querySelectorAll('[data-dynamic-multi-file-instance]');
             elements.forEach((el) => {


### PR DESCRIPTION
This PR fixes an issue with invalid recaptcha hash updates.

- The event listener for the error state of an ajax response was invalid and never called.
- One of the conditions for the success case was invalid (checking `length` on an input field) and was never called either.

This resulted in the issue, that a form could never be submitted twice without reloading the page.

You can test this locally by cloning this repository, then execute `npm link` in the repository folder, go to the project and execute `npm link js-pimcore-formbuilder` there.