### PR TITLE
Fixed failing conditional logic for html fields and snippets

### DIFF
--- a/src/js/components/conditionalLogic.js
+++ b/src/js/components/conditionalLogic.js
@@ -131,6 +131,13 @@ export default class ConditionalLogic {
                         if (action.fields) {
                             action.fields.forEach((fieldName) => {
                                 let field = this.form.querySelectorAll('[name*="' + fieldName + '"]');
+
+                                // There is also a BE Bug that not all elements are getting the name property.
+                                // This fixes the issue that no conditional logic can be defined for html elements and snippets.
+                                if (!field) {
+                                    field = this.form.querySelectorAll('[data-field-id*="' + fieldName + '"]');
+                                }
+
                                 if (doAction) {
                                     this.actions[action.type].onEnable(action, ev, field);
                                 } else {

--- a/src/js/components/conditionalLogic.js
+++ b/src/js/components/conditionalLogic.js
@@ -130,13 +130,13 @@ export default class ConditionalLogic {
 
                         if (action.fields) {
                             action.fields.forEach((fieldName) => {
-                                let field = this.form.querySelectorAll('[name*="' + fieldName + '"]');
+                                let field = this.form.querySelectorAll('[name*="' + fieldName + '"], [data-field-id*="' + fieldName + '"]');
 
                                 // There is also a BE Bug that not all elements are getting the name property.
                                 // This fixes the issue that no conditional logic can be defined for html elements and snippets.
-                                if (!field) {
-                                    field = this.form.querySelectorAll('[data-field-id*="' + fieldName + '"]');
-                                }
+                                // if (!field.length) {
+                                //     field = this.form.querySelectorAll('[data-field-id*="' + fieldName + '"]');
+                                // }
 
                                 if (doAction) {
                                     this.actions[action.type].onEnable(action, ev, field);


### PR DESCRIPTION
This PR fixed the issue with the html fields and snippets. Any conditional logic does not work for these elements as they do not provide a name attribute.